### PR TITLE
splash-bootlog: add COMPATIBLE_MACHINE

### DIFF
--- a/recipes-bsp/drivers/splash-bootlogo.bb
+++ b/recipes-bsp/drivers/splash-bootlogo.bb
@@ -3,6 +3,8 @@ SECTION = "base"
 PRIORITY = "required"
 PACKAGE_ARCH = "${MACHINE_ARCH}"
 
+COMPATIBLE_MACHINE = "fusion"
+
 require conf/license/openpli-gplv2.inc
 
 PV = "1.0"


### PR DESCRIPTION
Fixes #1  
