### PR TITLE
Set KERNEL_OUTPUT_DIR variable

### DIFF
--- a/recipes-bsp/drivers/xsarius-shutdown.bb
+++ b/recipes-bsp/drivers/xsarius-shutdown.bb
@@ -10,10 +10,7 @@ SRC_URI = " \
 INITSCRIPT_NAME = "xsarius-shutdown"
 INITSCRIPT_PARAMS = "start 89 0 ."
 
-inherit autotools pkgconfig update-rc.d
-
-do_compile() {
-}
+inherit pkgconfig update-rc.d
 
 do_install() {
     install -d ${D}/etc/init.d/

--- a/recipes-bsp/drivers/xsarius-shutdown.bb
+++ b/recipes-bsp/drivers/xsarius-shutdown.bb
@@ -12,6 +12,9 @@ INITSCRIPT_PARAMS = "start 89 0 ."
 
 inherit autotools pkgconfig update-rc.d
 
+do_compile() {
+}
+
 do_install() {
     install -d ${D}/etc/init.d/
     install -m 0755 ${WORKDIR}/xsarius-shutdown.sh ${D}/etc/init.d/xsarius-shutdown

--- a/recipes-bsp/linux/linux-xsarius_4.2.1.bb
+++ b/recipes-bsp/linux/linux-xsarius_4.2.1.bb
@@ -22,6 +22,7 @@ S = "${WORKDIR}/linux-${KV}"
 export OS = "Linux"
 KERNEL_OBJECT_SUFFIX = "ko"
 KERNEL_OUTPUT = "vmlinux"
+KERNEL_OUTPUT_DIR = "."
 KERNEL_IMAGETYPE = "vmlinux"
 KERNEL_IMAGEDEST = "/tmp"
 


### PR DESCRIPTION
KERNEL_OUTPUT_DIR defaults to arch/${ARCH}/boot, which isn't where
these kernels end up. Previously this was done with KERNEL_OUTPUT,
but now that the kernel class supports multiple recipes, setting
KERNEL_OUTPUT_DIR to "./" fixes the kernel recipes no longer
building.
