### PR TITLE
fixed typo causing the box to shutdown on updates

### DIFF
--- a/recipes-bsp/drivers/xsarius-shutdown.bb
+++ b/recipes-bsp/drivers/xsarius-shutdown.bb
@@ -23,12 +23,12 @@ do_install() {
 
 pkg_preinst_${PN}_prepend() {
 #!/bin/sh
-chmod -x $D/etc/init.d/dags-shutdown
+chmod -x $D/etc/init.d/xsarius-shutdown
 }
 
 pkg_postinst_${PN}_append() {
 #!/bin/sh
-chmod 755 $D/etc/init.d/dags-shutdown
+chmod 755 $D/etc/init.d/xsarius-shutdown
 }
 
 pkg_prerm_${PN}() {


### PR DESCRIPTION
pre- and post-inst scripts fail due to this typo.