### PR TITLE
Replace "base_contains" by "bb.utils.contains"

### DIFF
--- a/conf/machine/include/xsarius.inc
+++ b/conf/machine/include/xsarius.inc
@@ -13,7 +13,7 @@ MACHINE_ESSENTIAL_EXTRA_RDEPENDS = " \
 KERNEL_MODULE_AUTOLOAD += "xfs"
 
 MACHINE_EXTRA_RRECOMMENDS = " \
-	${@base_contains("DISTRO_VERSION", "4", "xsarius-gst-plugin-dvbmediasink", " \
+	${@bb.utils.contains("DISTRO_VERSION", "4", "xsarius-gst-plugin-dvbmediasink", " \
 	gstreamer1.0-plugin-xsarius-dvbmediasink gstreamer1.0-libav", d)} \
 	splash-bootlogo \
 	enigma2-plugin-extensions-hbbtv-xsarius \

--- a/conf/machine/include/xsarius4k.inc
+++ b/conf/machine/include/xsarius4k.inc
@@ -2,7 +2,7 @@
 MACHINE_FEATURES_BACKFILL_CONSIDERED = "rtc"
 
 MACHINE_ESSENTIAL_EXTRA_RDEPENDS = " \
-	${@base_contains("GST_VERSION", "1.0", "gstreamer1.0-libav", "gst-ffmpeg", d)} \
+	${@bb.utils.contains("GST_VERSION", "1.0", "gstreamer1.0-libav", "gst-ffmpeg", d)} \
         xsarius-initrd-${MACHINE} \
         xsarius-shutdown \
         xsarius-dvb-modules-bcm7252s \

--- a/recipes-bsp/drivers/splash-bootlogo.bb
+++ b/recipes-bsp/drivers/splash-bootlogo.bb
@@ -12,7 +12,7 @@ PR = "r0"
 S = "${WORKDIR}/"
 
 SRC_URI = " \
-	${@base_contains("MACHINE", "revo4k", "file://${MACHINE}_splash.bmp", " \
+	${@bb.utils.contains("MACHINE", "revo4k", "file://${MACHINE}_splash.bmp", " \
 	file://${MACHINE}_splash.bmp \
 	file://${MACHINE}_splash1.bmp \
 	file://${MACHINE}_splash2.bmp \

--- a/recipes-bsp/drivers/xsarius-gstreamer1.0-plugin-dvbmediasink.bb
+++ b/recipes-bsp/drivers/xsarius-gstreamer1.0-plugin-dvbmediasink.bb
@@ -5,13 +5,13 @@ LICENSE = "GPLv2"
 PACKAGE_ARCH = "${MACHINE_ARCH}"
 LIC_FILES_CHKSUM = "file://COPYING;md5=7fbc338309ac38fefcd64b04bb903e34"
 
-DEPENDS = "gstreamer1.0 gstreamer1.0-plugins-base libdca ${@base_contains("BRAND_OEM", "fulan", "fulan-dvb-modules" , "", d)}"
+DEPENDS = "gstreamer1.0 gstreamer1.0-plugins-base libdca ${@bb.utils.contains("BRAND_OEM", "fulan", "fulan-dvb-modules" , "", d)}"
 
 GSTVERSION = "1.0"
 
 #SRC_URI = "git://git.code.sf.net/p/openpli/gst-plugin-dvbmediasink;protocol=git;branch=gst-1.0"
 SRC_URI = "git://github.com/christophecvr/gstreamer1.0-plugin-multibox-dvbmediasink.git;protocol=git \
-	${@base_contains("CHIP", "73625", "file://0001.vp8_vp9_codec.patch", "", d)} \
+	${@bb.utils.contains("CHIP", "73625", "file://0001.vp8_vp9_codec.patch", "", d)} \
 "
 
 S = "${WORKDIR}/git"


### PR DESCRIPTION
Future OE versions emit warnings, solve them by running the following script:
find . -type f -exec sed -i 's/@base_contains/@bb.utils.contains/g' {} \;