### PR TITLE
fixed incorrect checksums

### DIFF
--- a/recipes-bsp/drivers/splash-bootlogo.bb
+++ b/recipes-bsp/drivers/splash-bootlogo.bb
@@ -27,4 +27,5 @@ do_deploy() {
 	install -m 0644 ${WORKDIR}/*.bmp ${DEPLOYDIR}
 }
 
+addtask deploy after do_unpack
 addtask deploy before do_build

--- a/recipes-bsp/linux/linux-xsarius_3.14.28.bb
+++ b/recipes-bsp/linux/linux-xsarius_3.14.28.bb
@@ -4,8 +4,8 @@ SECTION = "kernel"
 KV = "3.14.28"
 PR_INC = ".2"
 
-SRC_URI[md5sum] = "d83e48d38bf83c50f7a175bc6a1fd2ce"
-SRC_URI[sha256sum] = "9c04354eba2861304d09bce015b4d381c65f968ba445465a70a77bee3ee16f45"
+SRC_URI[md5sum] = "3b6d3fd2257b61789eebdebac5c597b2"
+SRC_URI[sha256sum] = "eb56d7e99ab9e869b6abfb2a0463015e7d7b2e8610b7b9d05285edb8e8dfaf4f"
 
 LIC_FILES_CHKSUM = "file://${WORKDIR}/linux/COPYING;md5=d7810fab7487fb0aad327b76f1be7cd7"
 


### PR DESCRIPTION
Please also add a SRCDATE to the filename, and change the recipe accordingly. 

Due to bitbake's caching mechanism, people with the old tar.xz file in cache will no longer be able to build, because bitbake doesn't see the difference and will not fetch the new file.